### PR TITLE
Use bicubic instead of bilinear

### DIFF
--- a/routes/i.js
+++ b/routes/i.js
@@ -540,9 +540,9 @@ async function saveImage(username, suffix, tmpPath, frame_w, frame_h, mimeType) 
   let h = img.bitmap.height;
   if (h > frame_h || w > frame_w) {
     if ((w/h) > (frame_w/frame_h)) {
-      await img.resize(frame_w, Jimp.AUTO);// 横長
+      await img.resize(frame_w, Jimp.AUTO, Jimp.RESIZE_BICUBIC); // 横長
     } else {
-      await img.resize(Jimp.AUTO, frame_h);　// 縦長
+      await img.resize(Jimp.AUTO, frame_h, Jimp.RESIZE_BICUBIC); // 縦長
     }
   }
 


### PR DESCRIPTION
This PR updates the resize algorithm on `saveImage`.

Bilinear(default algorithm) doesn't work well in many situations such as:

* When the resize factor is 1/N(N: integer), bilinear's behavior is the same as the nearest neighbor's, which causes terrible output.
* When the resize factor is large(>2), bilinear lost some original pixels.

One minor disadvantage of bicubic is CPU efficiency. But it seems reasonable for thumbnail generation.

## Diff(200x313 thumbnail)
bilinear
![bl-output](https://user-images.githubusercontent.com/3619579/74401989-4f29ed80-4e66-11ea-84dc-ba28b1d84a4e.png)

bicubic
![bc-output](https://user-images.githubusercontent.com/3619579/74402002-5c46dc80-4e66-11ea-9cb3-0f7a9f4d3763.png)
