### PR TITLE
:wrench: Enable source-map in development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "homepage": "https://www.meish.com/",
   "scripts": {
     "start": "node ./bin/www",
+    "build:dev": "webpack --mode=development",
     "build": "webpack --mode=production",
     "test": "NODE_PATH=app/ mocha --timeout 10000 --exit"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   context: __dirname + '/app',
   entry: './entry',
   mode: 'none',
@@ -24,3 +24,11 @@ module.exports = {
     }
   ]
 };
+
+module.exports = (env, argv) => {
+  // https://webpack.js.org/configuration/mode/
+  if (argv.mode === 'development') {
+    config.devtool = 'eval-source-map';
+  }
+  return config;
+}


### PR DESCRIPTION
先日のPRで気づいたのですが、development modeでもsource-mapが出てなかったので、出すようにします。

`webpack.config.js` は、もうちょっと大きくなってきたら設定ファイルを分割するようなプラクティスもあるようですが、今はフロントのJSはとても小さいですしwebpackの設定も複雑ではないので、PRのような方針でいいかなと思いました。