### PR TITLE
Topページのサムネイルを遅延ロードさせる

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -6,6 +6,10 @@ const global = Function('return this;')();
 global.jQuery = $;
 //import * as Vibrant from 'node-vibrant';
 
+// 画像の遅延ロードの有効化
+import lozad from 'lozad';
+lozad().observe();
+
 const imageValidate = (fileInput, form) => {
   let img = fileInput.prop('files')[0]; 
   if (!img) { return true; }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jimp": "^0.9.3",
     "jquery": "3.4.1",
     "jquery.easing": "^1.4.1",
+    "lozad": "^1.14.0",
     "magnific-popup": "^1.1.0",
     "morgan": "~1.9.0",
     "multer": "^1.4.2",

--- a/views/index.pug
+++ b/views/index.pug
@@ -46,7 +46,7 @@ block content
           .m-3
             a(href=`/i/${result.username}`)
               .thumbnail_frame.card
-                div(style=`background-image: url(${s3+result.thumbnail_path});` class=`${result.isSensitive ? "sensitive sensitive_on" : ""}`).thumbnail.card-img-top
+                div(data-background-image=`${s3+result.thumbnail_path}` class=`${result.isSensitive ? "sensitive sensitive_on" : ""}`).thumbnail.card-img-top.lozad
 
       // 表示制御系ボタン
       .text-center


### PR DESCRIPTION
## 課題意識とその解決手段
現在のMeishのトップページは、最大30件のサムネイルを並べてランダム表示するようになっています。この表示方式はレスポンシブになっているため、スマホのようなビューポートが小さいデバイスでも機能しますが、下の方にある（閲覧されづらいであろう）サムネイルも全力で読み込むため、データ転送量がかさみます。

実際、 オフスクリーン領域にある画像を大量に読み込むと、Lighthouseがすごく怒ってきます。Meish利用者にとっても、運営者にとっても、嬉しくないはずです。
<img width="40%" alt="Lighthouse performance score" src="https://user-images.githubusercontent.com/3619579/75087975-3ae2a080-558a-11ea-9e56-26b5915a59c7.png">

解決策として、画像が表示領域に差し掛かるまで読み込みを遅延させます。具体的な実装としては[lozad.js](https://github.com/ApoorvSaxena/lozad.js)を用いました。

## 気になっているところ
- lozad.jsはpolyfill足さないとIE11で動かないらしいが、足すかどうか（IE11対応する？）
- 画像ロード完了前の仮画像を置くことは機能的にはできるらしいが、いるか

## その他
- `package-lock.json` `bundle.js` はこのPRでは更新していません。後からいい感じにしてほしいです

## 参考資料
- [イメージと動画の遅延読み込み | Web Fundamentals | Google Developers](https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video?hl=ja)