### PR TITLE
Add noopener to external links

### DIFF
--- a/app/autolink.js
+++ b/app/autolink.js
@@ -18,12 +18,14 @@
         return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/'/g, '&#39;');
     }
 
-	function anchor(url, label, target) {
-		label = label || url;
-		target = target ? ' target="' + target + '"' : "";
-		
-		return '<a href="' + url + '"' + target + '>' + label + '</a>';
-	}
+    function anchor(url, label, target) {
+        // append 'rel="noopener"' if the target is '_blank'
+        // SEE: https://developers.google.com/web/tools/lighthouse/audits/noopener
+        const noopener = (target && target === '_blank') ? ' rel="noopener"' : '';
+        label = label || url;
+        target = target ? ' target="' + target + '"' : "";
+        return '<a href="' + url + '"' + target + noopener + '>' + label + '</a>';
+    }
 
     Y.autolink = function (src, target) {
         return src.replace(

--- a/test/test_autolink.js
+++ b/test/test_autolink.js
@@ -6,10 +6,10 @@ describe('autolink', () => {
         it('should replace @xxx with a twitter link to xxx', () => {
             assert.equal(
                 autolink.autolinkTwitter('@OkuriSae', '_blank'),
-                '<a href="http://twitter.com/OkuriSae" target="_blank">@OkuriSae</a>');
+                '<a href="http://twitter.com/OkuriSae" target="_blank" rel="noopener">@OkuriSae</a>');
             assert.equal(
                 autolink.autolinkTwitter('@OkuriSaeちゃん', '_blank'),
-                '<a href="http://twitter.com/OkuriSae" target="_blank">@OkuriSae</a>ちゃん');
+                '<a href="http://twitter.com/OkuriSae" target="_blank" rel="noopener">@OkuriSae</a>ちゃん');
         });
 
         it('should not replace mail addresses', () => {

--- a/views/howto.pug
+++ b/views/howto.pug
@@ -359,9 +359,9 @@ block content
           |サービスごとのキャッシュクリア方法をお試しください。
         ul
           li Twitter: 
-            a(href="https://cards-dev.twitter.com/validator" target="_blank") Card Validator
+            a(href="https://cards-dev.twitter.com/validator" target="_blank", rel="noopener") Card Validator
           li FaceBook: 
-            a(href="https://developers.facebook.com/tools/debug/og/object/" target="_blank") Open Graphオブジェクトデバッガー
+            a(href="https://developers.facebook.com/tools/debug/og/object/" target="_blank", rel="noopener") Open Graphオブジェクトデバッガー
           li Discord: キャッシュクリア方法は無いようなので、URLの末尾に『?適当な文字』をつけることで別URL扱いする方法があります。
             |（例: https://www.meish.me/i/OkuriSae?123）
 

--- a/views/i.pug
+++ b/views/i.pug
@@ -152,7 +152,7 @@ block content
                   +categorizedInfo('ハッシュタグ', 'HashTag')
                     each tag in hashTags
                       p.mx-2
-                        a(href="https://twitter.com/hashtag/"+tag.name target="_blank").no-shadow.font-weight-bold ##{tag.name}
+                        a(href="https://twitter.com/hashtag/"+tag.name target="_blank", rel="noopener").no-shadow.font-weight-bold ##{tag.name}
                         if tag.comment
                           span.text-secondary  - #{tag.comment}
 
@@ -162,7 +162,7 @@ block content
                     each activity in activities
                       p.mx-2
                         if activity.link
-                          a(href=activity.link target="_blank").no-shadow.font-weight-bold
+                          a(href=activity.link target="_blank", rel="noopener").no-shadow.font-weight-bold
                             img(src="/img/i/icons/"+getIcon(activity.link)).icon
                             span.mx-2 #{activity.name}
                         else
@@ -174,7 +174,7 @@ block content
                     each cheer in cheerings
                       p.mx-2 
                         if cheer.link
-                          a(href=cheer.link target="_blank").no-shadow.font-weight-bold
+                          a(href=cheer.link target="_blank", rel="noopener").no-shadow.font-weight-bold
                             img(src="/img/i/icons/"+getIcon(cheer.link)).icon
                             span.mx-2 #{cheer.name}
                         else
@@ -298,7 +298,7 @@ block content
           div.rounded.img-fluid.card-img-top
             img(src=`${ogpPath}` data-toggle="modal" data-target="#OgpModal").ogpImage.rounded.img-fluid
         p.text-secondary.mt-2 Twitter Card のプレビューやキャッシュ削除は
-          a(href="https://cards-dev.twitter.com/validator" target="_blank") こちら(Twitter Card validator)
+          a(href="https://cards-dev.twitter.com/validator" target="_blank", rel="noopener") こちら(Twitter Card validator)
 
     // サムネイル
     div.edit

--- a/views/privacy_policy.pug
+++ b/views/privacy_policy.pug
@@ -52,21 +52,21 @@ block content
           li Google AdSense
         p ユーザーはブラウザの設定によりCookieの送信を拒否することができます。
         p Meishから収集した情報の GOOGLE による使用については 
-          a(href="https://policies.google.com/technologies/partner-sites?hl=ja" target="_blank") こちら
+          a(href="https://policies.google.com/technologies/partner-sites?hl=ja" target="_blank", rel="noopener") こちら
           | をご覧ください。
         h5 Google Analytics
         p Meishではサイトの改善を行なうため、Google Analyticsを利用しています。
         p ユーザーはディスプレイ広告に対応する
-          a(href="https://tools.google.com/dlpage/gaoptout/" target="_blank") Googleアナリティクス機能によるデータ収集を無効化
+          a(href="https://tools.google.com/dlpage/gaoptout/" target="_blank", rel="noopener") Googleアナリティクス機能によるデータ収集を無効化
           |することや、
-          a(href="https://adssettings.google.com/u/0/authenticated?hl=ja" target="_blank") 広告設定
+          a(href="https://adssettings.google.com/u/0/authenticated?hl=ja" target="_blank", rel="noopener") 広告設定
           |を使用してGoogleディスプレイネットワークで表示される広告をカスタマイズすることができます。
         h5 Google AdSense
         p Google AdSenseではCookieを使用して、本サービスや他のサービスへの過去のアクセス情報に基づいてGoogleを含む第三者配信事業者が広告を配信します。
         p ユーザーは
-          a(href="http://www.google.com/ads/preferences/" target="_blank") Ads Preferences Manager
+          a(href="http://www.google.com/ads/preferences/" target="_blank", rel="noopener") Ads Preferences Manager
           |で、インタレスト ベースでの広告掲載に使用される DoubleClick Cookie を無効にできます。
         p 
-          a(href="http://www.aboutads.info/" target="_blank") aboutads.infoページ
+          a(href="http://www.aboutads.info/" target="_blank", rel="noopener") aboutads.infoページ
           |では、インタレスト ベースでの広告掲載に使用される第三者配信事業者の Cookie を無効にできます。
 


### PR DESCRIPTION
外部サイトへの `target="_blank"` によるリンクは `rel="noopener"` を付けることが推奨されているらしいので、付けます。

## 参考ページ
- [サイトで rel="noopener" を使用して外部アンカーを開く](https://developers.google.com/web/tools/lighthouse/audits/noopener)
- [HTML 本当は怖い target="_blank" 。rel="noopener" ってなに？](https://chaika.hatenablog.com/entry/2018/12/06/110000)