### PR TITLE
Add routing for robots.txt

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,6 +106,12 @@ app.get(
   }
 );
 
+// robots.txtへアクセスが来た時は空の200レスポンスを返す
+// c.f. https://stackoverflow.com/a/20265155/11169807
+app.get('/robots.txt', (req, res) => {
+  res.type('text/plain');
+  res.status(200).end();
+});
 app.use('/', indexRouter);
 app.use('/i/', iRouter);
 app.use('/logout', logoutRouter); 


### PR DESCRIPTION
Lighthouseの指摘事項の1つで、robots.txtが適切に返されていないというものがあります。

<img width="512" alt="Lighthouse result on SEO" src="https://user-images.githubusercontent.com/3619579/75579383-064e7780-5aa9-11ea-8b34-a045d998d3dc.png">

現在の実装だと `/robots.txt` へのアクセスは普通にHTMLを返しちゃっているっぽいです。

検索インデックスに載せてほしくないページは特に存在しないと思われるので、200 OKの空レスポンスを返すことにします。