### PR TITLE
Update title and description to fix #36

### DIFF
--- a/views/i.pug
+++ b/views/i.pug
@@ -1,5 +1,12 @@
 extends layout/layout
 
+block title
+  title #{personality.nameJa}のプロフィール - Meish* バーチャルプロフィール登録サービス
+
+block description
+  //- ここの生成ルールog:titleに揃えている
+  meta(name="description" content=personality.introduction.slice(0,200))
+
 block meta
 
   // OGP & Twitter Card

--- a/views/layout/layout.pug
+++ b/views/layout/layout.pug
@@ -1,7 +1,11 @@
 doctype html
 html
   head(prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# website: http://ogp.me/ns/websaite#")
-    title Meish* バーチャルプロフィール登録サービス
+    block title
+      title Meish* バーチャルプロフィール登録サービス
+
+    block description
+      meta(name="description" content="Meish*はバーチャルキャラクターのためのプロフィール登録サービスです。")
 
     meta(charset="utf-8")
     meta(http-equiv="X-UA-Compatible" content="IE=edge")


### PR DESCRIPTION
#36 を解決します。

確かに現状として、[site:meish.meの検索結果を見るに](https://www.google.com/search?q=site%3Ameish.me)結構な混乱があるようです。Googleがあまり正確にページを認識してくれていない気がします（立ち絵って……他のページはともかくプロフィールページは頑張りたい）。

実装の改修方針はそんなに変ではない気がするのですが、具体的な文言については調整したいです。

ついでに`<meta name="description ... />` の方も設定してみました。ただ、これも凝ることはできるが凝り始めると結構大変なやつだと思うので、どこまで頑張るかは要相談としたいです。

## 参考
- [検索結果に効果的に表示されるタイトルとスニペットを作成する](https://support.google.com/webmasters/answer/35624)